### PR TITLE
Improve standalone loading and error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - Add `Operandi::RuntimeError` with access to the failed service instance
 - Add the associated service class to `Operandi::ArgTypeError`
+- Add `Operandi::Messages#full_messages`
+
+### Fixed
+
+- Load Operandi without relying on other gems to require `forwardable`
+- Remove formatting artifacts from plain Ruby type errors
 
 ### Breaking changes
 

--- a/lib/operandi/collection.rb
+++ b/lib/operandi/collection.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "forwardable"
+
 require_relative "constants"
 
 module Operandi

--- a/lib/operandi/messages.rb
+++ b/lib/operandi/messages.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "forwardable"
+
 module Operandi
   # Collection of error or warning messages, organized by key.
   #
@@ -145,6 +147,21 @@ module Operandi
     # @return [Hash{Symbol => Array<String>}] messages as hash
     def to_h
       @messages.to_h.transform_values { |value| value.map(&:to_s) }
+    end
+
+    # Convert messages to human-readable strings.
+    #
+    # @return [Array<String>] fully formatted messages
+    def full_messages
+      @messages.flat_map do |key, messages|
+        messages.map do |message|
+          if key == :base
+            message.to_s.capitalize
+          else
+            "#{key.to_s.tr('_', ' ').capitalize} #{message}"
+          end
+        end
+      end
     end
 
     private

--- a/lib/operandi/settings/field.rb
+++ b/lib/operandi/settings/field.rb
@@ -123,8 +123,8 @@ module Operandi
 
       def type_error_message(value)
         expected_types = [*@type].map(&:to_s).join(" or ")
-        "#{@service_class} #{@field_type} `#{@name}` must be #{expected_types}, \" \\
-            \"but got #{value.class} with value: #{value.inspect}"
+        "#{@service_class} #{@field_type} `#{@name}` must be #{expected_types}, " \
+          "but got #{value.class} with value: #{value.inspect}"
       end
 
       def define_methods

--- a/rbi/operandi.rbi
+++ b/rbi/operandi.rbi
@@ -162,6 +162,9 @@ module Operandi
 
     sig { returns(T::Hash[Symbol, T::Array[String]]) }
     def to_h; end
+
+    sig { returns(T::Array[String]) }
+    def full_messages; end
   end
 
   module Collection

--- a/spec/operandi/messages_spec.rb
+++ b/spec/operandi/messages_spec.rb
@@ -106,6 +106,19 @@ RSpec.describe Operandi::Messages do
     end
   end
 
+  describe "#full_messages" do
+    it "returns capitalized base messages and humanized attribute messages" do
+      messages.add(:base, "request failed")
+      messages.add(:first_name, "can't be blank")
+
+      expect(messages.full_messages).to eq(["Request failed", "First name can't be blank"])
+    end
+
+    it "returns an empty array when there are no messages" do
+      expect(messages.full_messages).to eq([])
+    end
+  end
+
   describe "#copy_from" do
     context "with Operandi::Base object" do
       it "copies errors from service" do

--- a/spec/operandi/operandi_spec.rb
+++ b/spec/operandi/operandi_spec.rb
@@ -1,6 +1,24 @@
 # frozen_string_literal: true
 
+require "open3"
+require "rbconfig"
+
 RSpec.describe Operandi do
+  describe "standalone loading" do
+    it "loads without relying on other gems" do
+      lib_path = File.expand_path("../../lib", __dir__)
+      output, status = Open3.capture2e(
+        RbConfig.ruby,
+        "--disable-gems",
+        "-I#{lib_path}",
+        "-e",
+        'require "operandi"',
+      )
+
+      expect(status).to be_success, output
+    end
+  end
+
   describe ".config" do
     it do
       Operandi::Config::DEFAULTS.each_key do |param|

--- a/spec/operandi/settings/argument_spec.rb
+++ b/spec/operandi/settings/argument_spec.rb
@@ -51,7 +51,10 @@ RSpec.describe Operandi::Settings::Argument do
 
       it "rejects other types" do
         expect { WithMultipleTypes.run(value: 3.14) }
-          .to raise_error(Operandi::ArgTypeError, /(must be|expected) (String or Integer|T\.any)/)
+          .to raise_error(
+            Operandi::ArgTypeError,
+            "WithMultipleTypes argument `value` must be String or Integer, but got Float with value: 3.14",
+          )
       end
 
       it "rejects nil when not optional" do


### PR DESCRIPTION
## Summary

- explicitly require `forwardable` so Operandi loads without indirect dependencies
- add `Operandi::Messages#full_messages`, capitalizing base messages and humanizing attribute names
- clean up plain Ruby type-error formatting
- add the public RBI signature, changelog entries, and focused regression coverage

## Testing

- `bundle exec rspec` — 1,065 examples, 0 failures
- `bundle exec rubocop` — 132 files, no offenses
- `ruby --disable-gems -Ilib -e 'require \"operandi\"'`
- `ruby -c rbi/operandi.rbi`