### PR TITLE
Fix execution edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 
 - Load Operandi without relying on other gems to require `forwardable`
 - Remove formatting artifacts from plain Ruby type errors
+- Keep `run!` configuration scoped to a single context-wrapper invocation
+- Do not report `stop_immediately!` and `fail_immediately!` as step crashes
+- Do not retry a crashing step marked with `always: true`
 
 ### Breaking changes
 

--- a/lib/operandi/base_with_context.rb
+++ b/lib/operandi/base_with_context.rb
@@ -40,9 +40,9 @@ module Operandi
     # @param kwargs [Hash] keyword arguments matching service arguments
     # @return [Base] the executed service instance
     # @raise [RuntimeError] if the service fails
-    def run!(**)
-      @config[:raise_on_error] = true
-      run(**)
+    def run!(**kwargs)
+      config = @config.merge(raise_on_error: true)
+      @service_class.new(extend_arguments(kwargs), config, @parent_service).tap(&:call)
     end
 
     private

--- a/lib/operandi/concerns/execution.rb
+++ b/lib/operandi/concerns/execution.rb
@@ -35,7 +35,7 @@ module Operandi
           @cached_steps = self.class.steps
 
           @cached_steps.each do |name, step|
-            @launched_steps << name if step.run(self)
+            launch_step(name, step)
 
             break if @errors.break? || @warnings.break?
           end
@@ -56,8 +56,15 @@ module Operandi
         steps_to_check.each do |name, step|
           next if !step.always || @launched_steps.include?(name)
 
-          @launched_steps << name if step.run(self)
+          launch_step(name, step)
         end
+      end
+
+      def launch_step(name, step)
+        @launched_steps << name if step.run(self)
+      rescue StandardError
+        @launched_steps << name if step.always
+        raise
       end
 
       # Load defaults for outputs and arguments, then validate arguments

--- a/lib/operandi/settings/step.rb
+++ b/lib/operandi/settings/step.rb
@@ -71,9 +71,15 @@ module Operandi
         else
           instance.run_callbacks(:on_step_success, instance, name)
         end
+      rescue Operandi::StopExecution, Operandi::FailExecution
+        raise
       rescue StandardError => e
-        instance.run_callbacks(:on_step_crash, instance, name, e)
-        raise e
+        handle_crash(instance, e)
+      end
+
+      def handle_crash(instance, error)
+        instance.run_callbacks(:on_step_crash, instance, name, error)
+        raise error
       end
 
       def run?(instance)

--- a/spec/operandi/base_spec.rb
+++ b/spec/operandi/base_spec.rb
@@ -332,6 +332,38 @@ RSpec.describe Operandi::Base do
         expect(service.always_step_ran).to be(true)
       end
     end
+
+    context "when an always step raises an exception" do
+      let(:service_class) do
+        Class.new(Operandi::Base) do
+          output :attempts, type: Integer, default: 0
+          output :crash_count, type: Integer, default: 0
+
+          on_step_crash :count_crash
+
+          step :raise_error, always: true
+
+          private
+
+          def raise_error
+            self.attempts += 1
+            raise StandardError, "Always step exploded!"
+          end
+
+          def count_crash(_service, _step_name, _error)
+            self.crash_count += 1
+          end
+        end
+      end
+
+      it "runs the step and its crash callback only once" do
+        service = service_class.new
+
+        expect { service.call }.to raise_error(StandardError, "Always step exploded!")
+        expect(service.attempts).to eq(1)
+        expect(service.crash_count).to eq(1)
+      end
+    end
   end
 
   describe ".run" do
@@ -364,6 +396,15 @@ RSpec.describe Operandi::Base do
       it "applies config to service" do
         service = WithConditions.with(use_transactions: false).run(fake_error: true)
         expect(service.failed?).to be(true)
+      end
+    end
+
+    context "when reusing a context after run!" do
+      it "does not enable raise_on_error for later runs" do
+        context = WithConditions.with(use_transactions: false)
+
+        expect { context.run!(fake_error: true) }.to raise_error(Operandi::RuntimeError)
+        expect { context.run(fake_error: true) }.not_to raise_error
       end
     end
 

--- a/spec/operandi/callbacks_spec.rb
+++ b/spec/operandi/callbacks_spec.rb
@@ -151,6 +151,32 @@ RSpec.describe Operandi::Callbacks do
     end
 
     describe "on_step_crash" do
+      let(:control_flow_service_class) do
+        Class.new(Operandi::Base) do
+          arg :action, type: Symbol
+
+          output :callback_log, type: Array, default: -> { [] }
+
+          on_step_crash :log_step_crash
+
+          step :halt
+
+          private
+
+          def halt
+            if action == :stop
+              stop_immediately!
+            else
+              fail_immediately!("Expected failure")
+            end
+          end
+
+          def log_step_crash(_service, step_name, _error)
+            callback_log << [:on_step_crash, step_name]
+          end
+        end
+      end
+
       context "when step raises an exception" do
         it "is called with the exception" do
           service = WithCallbacksStepException.new
@@ -168,6 +194,22 @@ RSpec.describe Operandi::Callbacks do
           service = WithCallbacksStepException.new
           expect { service.call }.to raise_error(StandardError)
           expect(service.callback_log).not_to include([:on_step_success, :raise_error])
+        end
+      end
+
+      context "when step stops execution intentionally" do
+        it "is not called for stop_immediately!" do
+          service = control_flow_service_class.run(action: :stop)
+
+          expect(service.callback_log).to be_empty
+          expect(service.stopped?).to be(true)
+        end
+
+        it "is not called for fail_immediately!" do
+          service = control_flow_service_class.with(use_transactions: false).run(action: :fail)
+
+          expect(service.callback_log).to be_empty
+          expect(service.failed?).to be(true)
         end
       end
     end


### PR DESCRIPTION
## Summary

- keep `BaseWithContext#run!` configuration scoped to one invocation so reusable wrappers retain their original settings
- exclude `stop_immediately!` and `fail_immediately!` control flow from `on_step_crash` callbacks
- prevent a crashing `always: true` step and its crash callback from running twice
- add focused regression coverage and update the changelog

## Testing

- `bundle exec rspec` (1,069 examples, 0 failures)
- `bundle exec rubocop` (132 files, no offenses)
- `git diff --check`