### PR TITLE
Harden generated calls, messages, and DSL options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 - Keep `run!` configuration scoped to a single context-wrapper invocation
 - Do not report `stop_immediately!` and `fail_immediately!` as step crashes
 - Do not retry a crashing step marked with `always: true`
+- Generate keyword-compatible service specs and update positional-hash documentation examples
+- Validate all message texts before adding any and reject empty arrays consistently
+- Reject unknown `arg`, `output`, and `step` options
 
 ### Breaking changes
 

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -92,12 +92,12 @@ Now we can refactor our controller:
 ```ruby
 class PostsController < ApplicationController
   def index
-    service = Post::FindAll.run(service_args)
+    service = Post::FindAll.run(**service_args)
     render json: service.posts
   end
 
   def create
-    service = Post::Create.run(service_args(attributes: params[:post]))
+    service = Post::Create.run(**service_args(attributes: params[:post]))
 
     if service.success?
       render json: service.post
@@ -107,7 +107,7 @@ class PostsController < ApplicationController
   end
 
   def unpublish
-    service = Post::Unpublish.run(service_args(id: params[:id]))
+    service = Post::Unpublish.run(**service_args(id: params[:id]))
 
     if service.success?
       render json: service.post

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -4,11 +4,11 @@ This section covers the core concepts of Operandi: **Arguments**, **Steps**, **O
 
 ## Service Execution Flow
 
-When you call `MyService.run(args)`, the following happens:
+When you call `MyService.run(**args)`, the following happens:
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
-│                      Service.run(args)                       │
+│                     Service.run(**args)                      │
 ├──────────────────────────────────────────────────────────────┤
 │  1. Load default values for arguments and outputs            │
 │  2. Validate argument types                                  │

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,11 +78,8 @@ end
 Override configuration for a single service call:
 
 ```ruby
-# Pass config as second argument to run
-MyService.run({ name: "John" }, { raise_on_error: true })
-
-# Or use with() for context-based calls
-MyService.with({ raise_on_error: true }).run(name: "John")
+# Pass runtime configuration with with()
+MyService.with(raise_on_error: true).run(name: "John")
 
 # Combine with parent service context
 ChildService
@@ -96,7 +93,7 @@ Configuration is merged in this order (later overrides earlier):
 
 1. Global configuration (from initializer)
 2. Per-service configuration (from `config` class method)
-3. Per-call configuration (from `run` or `with` arguments)
+3. Per-call configuration (from `with` arguments)
 
 ```ruby
 # Global: raise_on_error = false
@@ -110,7 +107,7 @@ class MyService < ApplicationService
 end
 
 # Per-call: raise_on_error = false (overrides per-service)
-MyService.run(args, { raise_on_error: false })
+MyService.with(raise_on_error: false).run(**args)
 ```
 
 ## Common Configuration Patterns

--- a/docs/crud.md
+++ b/docs/crud.md
@@ -391,7 +391,7 @@ module CRUDControllers
         service_class = default_class
       end
 
-      service_class.run(service_args(args))
+      service_class.run(**service_args(args))
     end
   end
 end
@@ -498,7 +498,7 @@ module CRUDServices
 
       service_class
         .with(self)
-        .run(args)
+        .run(**args)
         .public_send(resource_name(klass, plural: opts[:plural_output]))
     end
   end

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -199,7 +199,7 @@ end
 Operandi provides convenient methods to check error/warning states:
 
 ```ruby
-service = MyService.run(args)
+service = MyService.run(**args)
 
 # Check if service has any errors
 service.failed?   # => true/false

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -119,7 +119,7 @@ service = GreetService.run!(name: "John")
 This is equivalent to:
 
 ```ruby
-service = GreetService.run({ name: "John" }, { raise_on_error: true })
+service = GreetService.with(raise_on_error: true).run(name: "John")
 ```
 
 {% hint style="info" %}

--- a/docs/service-rendering.md
+++ b/docs/service-rendering.md
@@ -9,7 +9,7 @@ Without a helper, controller actions become repetitive:
 ```ruby
 class PostsController < ApplicationController
   def create
-    service = Post::Create.run(service_args(attributes: params[:post]))
+    service = Post::Create.run(**service_args(attributes: params[:post]))
 
     if service.success?
       render json: service.post, status: :created
@@ -19,7 +19,7 @@ class PostsController < ApplicationController
   end
 
   def update
-    service = Post::Update.run(service_args(record: @post, attributes: params[:post]))
+    service = Post::Update.run(**service_args(record: @post, attributes: params[:post]))
 
     if service.success?
       render json: service.post
@@ -72,16 +72,16 @@ end
 ```ruby
 class PostsController < ApplicationController
   def create
-    render_service Post::Create.run(service_args(attributes: params[:post])), 
+    render_service Post::Create.run(**service_args(attributes: params[:post])),
                    success_status: :created
   end
 
   def update
-    render_service Post::Update.run(service_args(record: @post))
+    render_service Post::Update.run(**service_args(record: @post))
   end
 
   def destroy
-    render_service Post::Destroy.run(service_args(record: @post))
+    render_service Post::Destroy.run(**service_args(record: @post))
   end
 end
 ```
@@ -141,7 +141,7 @@ end
 ```ruby
 class PostsController < ApplicationController
   def create
-    service = Post::Create.run(service_args(attributes: params[:post]))
+    service = Post::Create.run(**service_args(attributes: params[:post]))
     
     render_service service,
                    success_status: :created,
@@ -149,7 +149,7 @@ class PostsController < ApplicationController
   end
 
   def bulk_create
-    service = Post::BulkCreate.run(service_args(items: params[:posts]))
+    service = Post::BulkCreate.run(**service_args(items: params[:posts]))
     
     render_service service,
                    success_status: :created,
@@ -183,7 +183,7 @@ end
 ```ruby
 class PostsController < ApplicationController
   def show
-    service = Post::Find.run(service_args(id: params[:id]))
+    service = Post::Find.run(**service_args(id: params[:id]))
     render_service service, serializer: PostSerializer
   end
 end

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -208,7 +208,7 @@ RSpec.describe MyService do
   describe "with raise_on_error config" do
     it "raises exception when configured" do
       expect {
-        described_class.run({ invalid: true }, { raise_on_error: true })
+        described_class.with(raise_on_error: true).run(invalid: true)
       }.to raise_error(Operandi::RuntimeError)
     end
 

--- a/lib/generators/operandi/service/templates/service_spec.rb.tt
+++ b/lib/generators/operandi/service/templates/service_spec.rb.tt
@@ -29,7 +29,7 @@ RSpec.describe <%= class_name %>, type: :service do
 
 <% end -%>
   describe "#run" do
-    subject(:service) { described_class.run(args) }
+    subject(:service) { described_class.run(**args) }
 
     let(:args) { {} }
 

--- a/lib/operandi/dsl/arguments_dsl.rb
+++ b/lib/operandi/dsl/arguments_dsl.rb
@@ -38,6 +38,7 @@ module Operandi
         #   arg :current_user, type: User, context: true
         def arg(name, opts = {})
           Validation.validate_symbol_name!(name, :argument, self)
+          OptionsValidation.validate!(name, :argument, self, opts)
           Validation.validate_reserved_name!(name, :argument, self)
           Validation.validate_name_conflicts!(name, :argument, self)
           Validation.validate_type_required!(name, :argument, self, opts)

--- a/lib/operandi/dsl/outputs_dsl.rb
+++ b/lib/operandi/dsl/outputs_dsl.rb
@@ -34,6 +34,7 @@ module Operandi
         #   output :metadata, type: Hash, default: -> { {} }
         def output(name, opts = {})
           Validation.validate_symbol_name!(name, :output, self)
+          OptionsValidation.validate!(name, :output, self, opts)
           Validation.validate_reserved_name!(name, :output, self)
           Validation.validate_name_conflicts!(name, :output, self)
           Validation.validate_type_required!(name, :output, self, opts)

--- a/lib/operandi/dsl/steps_dsl.rb
+++ b/lib/operandi/dsl/steps_dsl.rb
@@ -21,6 +21,7 @@ module Operandi
         # @option opts [Boolean] :always (false) Run step even after errors/warnings
         # @option opts [Symbol] :before Insert this step before the specified step
         # @option opts [Symbol] :after Insert this step after the specified step
+        # @option opts [Boolean] :parent Mark the step method as inherited for static analysis
         #
         # @example Define a simple step
         #   step :validate_input
@@ -40,6 +41,7 @@ module Operandi
         #   step :premium_feature, if: -> { user.premium? && feature_enabled? }
         def step(name, opts = {}) # rubocop:disable Metrics/MethodLength
           Validation.validate_symbol_name!(name, :step, self)
+          OptionsValidation.validate!(name, :step, self, opts)
           Validation.validate_reserved_name!(name, :step, self)
           Validation.validate_name_conflicts!(name, :step, self)
           validate_step_opts!(name, opts)

--- a/lib/operandi/dsl/validation.rb
+++ b/lib/operandi/dsl/validation.rb
@@ -4,6 +4,35 @@ require_relative "../constants"
 
 module Operandi
   module Dsl
+    # Validates options accepted by argument, output, and step declarations
+    module OptionsValidation
+      VALID_OPTIONS = {
+        argument: [:type, :optional, :default, :context].freeze,
+        output: [:type, :optional, :default].freeze,
+        step: [:if, :unless, :always, :before, :after, :parent].freeze,
+      }.freeze
+
+      # Validate that only supported DSL options are provided
+      #
+      # @param name [Symbol] the argument, output, or step name
+      # @param field_type [Symbol] the DSL type (:argument, :output, or :step)
+      # @param service_class [Class] the service class for error messages
+      # @param opts [Hash] the options hash to validate
+      def self.validate!(name, field_type, service_class, opts)
+        valid_options = VALID_OPTIONS.fetch(field_type)
+        unknown_options = opts.keys - valid_options
+        return if unknown_options.empty?
+
+        option_label = unknown_options.one? ? "option" : "options"
+        formatted_unknown = unknown_options.map { |option| "`#{option}`" }.join(", ")
+        formatted_valid = valid_options.map { |option| "`#{option}`" }.join(", ")
+
+        raise Operandi::Error,
+              "Unknown #{option_label} #{formatted_unknown} for #{field_type} `#{name}` in #{service_class}. " \
+              "Valid options: #{formatted_valid}"
+      end
+    end
+
     # Shared validation logic for DSL modules
     module Validation
       # Validate that the name is a symbol

--- a/lib/operandi/messages.rb
+++ b/lib/operandi/messages.rb
@@ -88,18 +88,11 @@ module Operandi
     # @example Add multiple errors
     #   errors.add(:email, ["is invalid", "is already taken"])
     def add(key, texts, opts = {})
-      raise_error("Error must be a non-empty string") unless texts
+      new_messages = build_messages(key, texts, opts)
 
-      message = nil
-
-      [*texts].each do |text|
-        message = text.is_a?(Message) ? text : Message.new(key, text, opts)
-
-        raise_error("Error must be a non-empty string") unless valid_error_text?(message.text)
-
-        @messages[key] ||= []
-        @messages[key] << message
-      end
+      @messages[key] ||= []
+      @messages[key].concat(new_messages)
+      message = new_messages.last
 
       raise!(message)
       break!(opts.key?(:break) ? opts[:break] : message.break?)
@@ -165,6 +158,15 @@ module Operandi
     end
 
     private
+
+    def build_messages(key, texts, opts)
+      messages = [*texts].map { |text| text.is_a?(Message) ? text : Message.new(key, text, opts) }
+      valid = messages.any? && messages.all? { |message| valid_error_text?(message.text) }
+
+      raise_error("Error must be a non-empty string") unless valid
+
+      messages
+    end
 
     def valid_error_text?(text)
       return false unless text.is_a?(String)

--- a/spec/generators/operandi/service_generator_spec.rb
+++ b/spec/generators/operandi/service_generator_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe "Operandi::Generators::ServiceGenerator" do
       )
 
       expect(content).to include('describe "#run"')
-      expect(content).to include("subject(:service) { described_class.run(args) }")
+      expect(content).to include("subject(:service) { described_class.run(**args) }")
     end
 
     it "generates namespaced spec" do

--- a/spec/operandi/messages_spec.rb
+++ b/spec/operandi/messages_spec.rb
@@ -57,6 +57,22 @@ RSpec.describe Operandi::Messages do
           .to raise_error(Operandi::RuntimeError, "Error must be a non-empty string")
       end
     end
+
+    context "when texts is an empty array" do
+      it "raises an error without adding a message" do
+        expect { messages.add(:base, []) }
+          .to raise_error(Operandi::RuntimeError, "Error must be a non-empty string")
+        expect(messages).to be_empty
+      end
+    end
+
+    context "when one of multiple texts is invalid" do
+      it "does not add any of the texts" do
+        expect { messages.add(:base, ["valid error", ""]) }
+          .to raise_error(Operandi::RuntimeError, "Error must be a non-empty string")
+        expect(messages).to be_empty
+      end
+    end
   end
 
   describe "#break?" do

--- a/spec/operandi/settings/argument_spec.rb
+++ b/spec/operandi/settings/argument_spec.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 RSpec.describe Operandi::Settings::Argument do
+  describe "option validation" do
+    it "rejects unknown options" do
+      expect do
+        Class.new(Operandi::Base) do
+          arg :name, type: String, optionnal: true
+        end
+      end.to raise_error(Operandi::Error, /Unknown option `optionnal`.*Valid options:.*`optional`/)
+    end
+  end
+
   describe "type validation" do
     describe "with boolean type" do
       it "accepts true" do

--- a/spec/operandi/settings/output_spec.rb
+++ b/spec/operandi/settings/output_spec.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 RSpec.describe Operandi::Settings::Output do
+  describe "option validation" do
+    it "rejects unknown options" do
+      expect do
+        Class.new(Operandi::Base) do
+          output :result, type: Hash, defualt: {}
+        end
+      end.to raise_error(Operandi::Error, /Unknown option `defualt`.*Valid options:.*`default`/)
+    end
+  end
+
   describe "type validation" do
     describe "with Class type" do
       it "accepts instances of the class" do

--- a/spec/operandi/step_spec.rb
+++ b/spec/operandi/step_spec.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 RSpec.describe Operandi::Settings::Step do
+  describe "option validation" do
+    it "rejects unknown options" do
+      expect do
+        Class.new(Operandi::Base) do
+          step :process, alway: true
+        end
+      end.to raise_error(Operandi::Error, /Unknown option `alway`.*Valid options:.*`always`/)
+    end
+  end
+
   describe "step ordering" do
     describe "with before: option" do
       let(:service) { WithStepInsertion.run }


### PR DESCRIPTION
## Summary

- generate service specs with keyword-splatted `.run` arguments and repair stale positional-hash examples across the documentation
- validate complete `Messages#add` batches before mutating the collection, including clean handling for empty arrays
- reject unknown `arg`, `output`, and `step` options with actionable errors that list the supported options
- add focused regression coverage and update the changelog

## Testing

- `bundle exec rspec` (1,074 examples, 0 failures)
- `bundle exec rubocop` (132 files, no offenses)
- `git diff --check`